### PR TITLE
declarative devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,10 @@
 {
   "image": "mcr.microsoft.com/devcontainers/universal:2",
   "hostRequirements": {
-    "cpus": 4
-  },
+		"cpus": 6,
+		"memory": "112gb",
+		"storage": "128gb" 
+	},
   "waitFor": "onCreateCommand",
   "updateContentCommand": "python3 -m pip install -r requirements.txt",
   "postCreateCommand": "",


### PR DESCRIPTION
Hey @blackgirlbytes! If you want users of your repo to get a one-click GPU codespace by default, feel free to merge this PR. It will not allow CPUs to be used, which is probably ok for now since the repo requires cuda. 